### PR TITLE
added basic HTTP authorization config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Constructor for a Suds SOAP web service client.
 	* targetNamespace - the namespace for your service data structures and prefix for SOAP actions - will be in your service WSDL
 	* envelopeBegin (optional) - a string containing the XML preceding the contents of the SOAP request body
 	* envelopeEnd (optional) - a string containing the XML following the contents of the SOAP request body
+	* authorization (optional) - a string used to specify basic HTTP authorization in the request header
 	
 ### `sudsClient.invoke(soapAction, body, callback(xmlDoc))`
 

--- a/suds.js
+++ b/suds.js
@@ -133,6 +133,9 @@ function SudsClient(_options) {
         xhr.setRequestHeader('Content-Type', 'text/xml');
         xhr.setRequestHeader('Content-Length', sendXML.length);
         xhr.setRequestHeader('SOAPAction', soapAction);
+        if (config.authorization !== undefined) {
+	  xhr.setRequestHeader('Authorization', 'Basic ' + config.authorization);
+	}
         xhr.send(sendXML);
   };
 }


### PR DESCRIPTION
I just added a simple config option to allow you to specify basic HTTP authorization in the request header.  Pretty basic, works well for me.
